### PR TITLE
add renv::init(bare = T) to the renv restore tmpl

### DIFF
--- a/R/slurmworkflow_helpers.R
+++ b/R/slurmworkflow_helpers.R
@@ -140,6 +140,7 @@ step_tmpl_renv_restore <- function(git_branch, setup_lines = NULL) {
     "exit 1",
     "fi",
     "git pull",
+    "Rscript -e \"renv::init(bare = TRUE)\"",
     "Rscript -e \"renv::restore()\""
   )
   instructions <- slurmworkflow::helper_use_setup_lines(instructions, setup_lines)


### PR DESCRIPTION
This ensures that renv is always used with the current R version but do nothing if the project is already initialized (thanks to `bare = TRUE`)

fixes #26 