### PR TITLE
add missing elements to restart

### DIFF
--- a/R/netsim_scenarios.R
+++ b/R/netsim_scenarios.R
@@ -137,7 +137,8 @@ make_save_elements <- function(save_pattern) {
     need_restart <- c(
       "param", "control", "epi",
       "nwparam", "attr", "temp",
-      "el", "el.cuml", "_last_unique_id"
+      "el", "el.cuml", "_last_unique_id",
+      "coef.form", "num.nw", "el", "network"
     )
     save_elements <- union(save_elements, need_restart)
     save_elements <- setdiff(save_elements, "restart")


### PR DESCRIPTION
add the missing elements to the restart save pattern
additions from `multinets`

note backward compatibility is assured as an absent element does not cause an error