### PR TITLE
Fix bug in `get_scenarios_batches_infos`

### DIFF
--- a/R/netsim_scenarios.R
+++ b/R/netsim_scenarios.R
@@ -248,7 +248,7 @@ get_scenarios_batches_infos <- function(scenario_dir) {
   )
 
   tidyr::separate(
-    .data$parts, .data$simple_name, sep = "__", remove = TRUE,
+    parts, .data$simple_name, sep = "__", remove = TRUE,
     into = c(NA, "scenario_name", "batch_number")
   )
 # nolint end


### PR DESCRIPTION
`parts` is the name of the `data.frame` and should not be prepended with `.data$`